### PR TITLE
Corrected error handling

### DIFF
--- a/src/commands/show.py
+++ b/src/commands/show.py
@@ -12,7 +12,7 @@ class Show:
             if arguments['parameter'] in shell.session.content.keys():
                 shell.session.content[arguments['parameter']].show(secure)
 
-        except:
+        except IndexError:
             Utils.print('error with command see usage below :')
             Show.help(shell)
 

--- a/src/session.py
+++ b/src/session.py
@@ -4,6 +4,9 @@
 
 from getpass import getpass
 import os
+
+import cryptography
+
 from src.password import Password
 from src.utils import *
 from src.cryptpath import CRYPTPATH
@@ -31,7 +34,7 @@ class SessionEnvironment():
             passwd = getpass('[passphrase] > ')
             try:
                 self.update(passwd)
-            except:
+            except cryptography.fernet.InvalidToken:
                 self.name = None
                 Utils.print(' -- wrong file key --')
                 return False


### PR DESCRIPTION
Added explicit exception names in `except` clauses in:
 - `commands/show.py` when the directory is empty (`IndexError`)
 - `session.py` when the password to start a session is invalid (`TokenError` in the `cryptography` package)