### PR TITLE
Refactored CD and modified Shell

### DIFF
--- a/src/commands/cd.py
+++ b/src/commands/cd.py
@@ -12,12 +12,8 @@ class Cd:
             return
         parameter, _ = shell.get_arguments(line)
         if parameter == '..':
-            shell.session.close_session()
-            shell.prompt = shell.session.prompt
-            return
-        elif shell.session.start_session(parameter):
-            shell.prompt = shell.session.prompt
-        else:
+            shell.close_session()
+        elif not shell.start_session(parameter):
             Cd.help(shell)
 
     @staticmethod

--- a/src/shell.py
+++ b/src/shell.py
@@ -12,10 +12,23 @@ class Shell(cmd.Cmd):
     def __init__(self, session) -> None:
         super().__init__()
         self.session: SessionEnvironment = session
-        self.prompt: str = self.session.prompt
+        self.update_prompt()
 
     def close(self):
         sys.exit()
+
+    def update_prompt(self) -> None:
+        self.prompt = self.session.prompt
+
+    def start_session(self, session_name: str) -> bool:
+        if self.session.start_session(session_name):
+            self.update_prompt()
+            return True
+        return False
+
+    def close_session(self) -> None:
+        self.session.close_session()
+        self.update_prompt()
 
     def get_arguments(self, line: str) -> Tuple[str, List[str]]:
         if line:


### PR DESCRIPTION
I simplified the code in the `Cd.do()` method. For this I had to add methods in the `Shell` class. 

I have one more general remark related to this: The fact that the session object starts and closes itself is weird. It should be the shell responsibility, why not have a `Shell.start_session()` and `Shell.close_session()` (as I added in the PR) that create (or delete) a new `SessionEnvironment` object. 

Doing so would have consequences on the code and would require more work but for now the `Shell` and `SessionEnvironment` have a too high coupling IMHO.
